### PR TITLE
Update Node to v6.11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ env:
   - CXX=g++-4.9
 language: node_js
 node_js:
-  - 4.2
-  - stable
+  - "6.10"
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   - CXX=g++-4.9
 language: node_js
 node_js:
-  - "6.10"
+  - "6.11"
 addons:
   apt:
     sources:

--- a/Box2D.es6
+++ b/Box2D.es6
@@ -17,3 +17,4 @@ export default reduce(
     ) : box2d,
   box2d
 );
+module.exports = exports.default;

--- a/Box2D.js
+++ b/Box2D.js
@@ -1,9 +1,8 @@
 'use strict';
-Object.defineProperty(exports, '__esModule', {
+
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 var _bindings = require('bindings');
 
@@ -11,12 +10,17 @@ var _bindings2 = _interopRequireDefault(_bindings);
 
 var _lodash = require('lodash');
 
-let box2d = (0, _bindings2.default)('Box2D.node'),
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var box2d = (0, _bindings2.default)('Box2D.node'),
     regexp = new RegExp('^b2');
 
-exports.default = (0, _lodash.reduce)(box2d, (box2d, val, key) => regexp.test(key) ? Object.assign(box2d, {
-  [key.replace(regexp, '')]: val
-}) : box2d, box2d);
+exports.default = (0, _lodash.reduce)(box2d, function (box2d, val, key) {
+  return regexp.test(key) ? Object.assign(box2d, _defineProperty({}, key.replace(regexp, ''), val)) : box2d;
+}, box2d);
+
 module.exports = exports.default;
 
 //# sourceMappingURL=Box2D.js.map

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install node-gyp -g
 npm install box2d-native
 ```
 
-**IMPORTANT:** Installation tested only with Node.js 6.10.3 and gc++ 4.9.
+**IMPORTANT:** Installation tested only with Node.js 6.11.2 and gc++ 4.9.
 
 ## Usage
 
@@ -35,7 +35,7 @@ Original "namespaced" Box2D classes (`b2Vec2`, `b2World`...) are also exposed.
 
 ## Demo
 
-**IMPORTANT:** Runs only with Node.js v6.10.3
+**IMPORTANT:** Runs only with Node.js v6.11.2
 
 ```
 npm install node-gyp -g

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ## Details
 
-Box2D compiled as static library, Node.js C++ addon produced by [swig](http://www.swig.org/).
+Box2D compiled as static library, Node.js C++ addon produced by [SWIG](http://www.swig.org/).
 
 ## Install
 
-Requires `curl`, `make`, `cmake`, `g++`. See also requirements for building [swig](http://www.swig.org/) and [node-gyp](https://www.npmjs.com/package/node-gyp)
+Requires `curl`, `make`, `cmake`, `g++`. See also requirements for building [SWIG](http://www.swig.org/) and [node-gyp](https://www.npmjs.com/package/node-gyp)
 
 Install with [NPM](https://www.npmjs.com/):
 
@@ -18,7 +18,7 @@ npm install node-gyp -g
 npm install box2d-native
 ```
 
-**IMPORTANT:** Installation tested only on Linux with Node.js >= 4.2.1 and gc++ 4.9.
+**IMPORTANT:** Installation tested only with Node.js 6.10.3 and gc++ 4.9.
 
 ## Usage
 
@@ -35,12 +35,14 @@ Original "namespaced" Box2D classes (`b2Vec2`, `b2World`...) are also exposed.
 
 ## Demo
 
-**IMPORTANT:** Runs only with Node.js v4.2.1
+**IMPORTANT:** Runs only with Node.js v6.10.3
 
 ```
 npm install node-gyp -g
-git checkout https://github.com/zuker/box2d-native.git
-cd box2d-native/demo
+git clone https://github.com/zuker/box2d-native.git
+cd box2d-native
+npm install
+cd demo
 npm install
 npm start
 ```

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,84 +1,88 @@
 'use strict';
 let Box2D = require('box2d-native');
 let World = Box2D.World;
-let Vec2 = Box2D.Vec2;
 let b2Vec2 = Box2D.b2Vec2;
 let b2Draw = Box2D.b2Draw;
 let b2Shape = Box2D.b2Shape;
+let b2EdgeShape = Box2D.b2EdgeShape;
+let b2CircleShape = Box2D.b2CircleShape;
+let b2BodyDef = Box2D.b2BodyDef;
+let b2_staticBody = Box2D.b2_staticBody;
+let b2_kinematicBody = Box2D.b2_kinematicBody;
+let b2_dynamicBody = Box2D.b2_dynamicBody;
 let b2Mul = Box2D.b2Mul;
 let b2Assert = Box2D.b2Assert;
 let b2_maxPolygonVertices = Box2D.b2_maxPolygonVertices;
 let b2Color = Box2D.b2Color;
-let world = new World(new Vec2(0, -9.8));
-let step;
 
-var bd_ground = new Box2D.b2BodyDef();
-var bd_circle = new Box2D.b2BodyDef();
-bd_circle.position = new Vec2(20, 120);
-bd_circle.type = Box2D.b2_dynamicBody;
-var ground = world.CreateBody(bd_ground);
-var circle = world.CreateBody(bd_circle);
+let world = new World(new b2Vec2(0, -9.8));
 
-var shape = new Box2D.b2EdgeShape();
-let circleShape = new Box2D.b2CircleShape();
+function CreateTestObjects() {
+  var bd_ground = new b2BodyDef();
+  var bd_circle = new b2BodyDef();
+  bd_circle.position = new b2Vec2(20, 120);
+  bd_circle.type = b2_dynamicBody;
+  var ground = world.CreateBody(bd_ground);
+  var circle = world.CreateBody(bd_circle);
 
-circleShape.m_radius = 10;
-shape.Set(new Box2D.b2Vec2(-40.0, 0.0), new Box2D.b2Vec2(40.0, 0.0));
+  var shape = new b2EdgeShape();
+  let circleShape = new b2CircleShape();
 
-let fixture = ground.CreateFixture(shape, 0.0);
-let circleFixture = circle.CreateFixture(circleShape, 0.0);
-circleFixture.SetRestitution(0.5);
+  circleShape.m_radius = 10;
+  shape.Set(new b2Vec2(-40.0, 0.0), new b2Vec2(40.0, 0.0));
+
+  let fixture = ground.CreateFixture(shape, 0.0);
+  let circleFixture = circle.CreateFixture(circleShape, 0.0);
+  circleFixture.SetRestitution(0.5);
+}
 
 function DrawShape(fixture, xf, color, g_debugDraw) {
   let shape = fixture.GetShape();
-  switch (fixture.GetType())
-  {
+  switch (fixture.GetType()) {
     case b2Shape.e_circle:
-    {
-      let center = b2Mul(xf, shape.m_p);
-      let radius = shape.m_radius;
-      let axis = b2Mul(xf.q, new b2Vec2(1.0, 0.0));
+      {
+        let center = b2Mul(xf, shape.m_p);
+        let radius = shape.m_radius;
+        let axis = b2Mul(xf.q, new b2Vec2(1.0, 0.0));
         g_debugDraw.DrawSolidCircle(center, radius, axis, color);
-    }
+      }
       break;
 
     case b2Shape.e_edge:
-    {
-      let v1 = b2Mul(xf, shape.m_vertex1);
-      let v2 = b2Mul(xf, shape.m_vertex2);
+      {
+        let v1 = b2Mul(xf, shape.m_vertex1);
+        let v2 = b2Mul(xf, shape.m_vertex2);
         g_debugDraw.DrawSegment(v1, v2, color);
-    }
+      }
       break;
 
     case b2Shape.e_chain:
-    {
-      let count = shape.m_count;
-      const vertices = shape.m_vertices;
-
-      let v1 = b2Mul(xf, vertices[0]);
-      for (let i = 1; i < count; ++i)
       {
-        let v2 = b2Mul(xf, vertices[i]);
+        let count = shape.m_count;
+        const vertices = shape.m_vertices;
+
+        let v1 = b2Mul(xf, vertices[0]);
+        for (let i = 1; i < count; ++i) {
+          let v2 = b2Mul(xf, vertices[i]);
           g_debugDraw.DrawSegment(v1, v2, color);
           g_debugDraw.DrawCircle(v1, 0.05, color);
-        v1 = v2;
+          v1 = v2;
+        }
       }
-    }
       break;
 
     case b2Shape.e_polygon:
-    {
-      let vertexCount = shape.m_count;
-      b2Assert(vertexCount <= b2_maxPolygonVertices);
-      let vertices = new Array(b2_maxPolygonVertices);
-
-      for (let i = 0; i < vertexCount; ++i)
       {
-        vertices[i] = b2Mul(xf, shape.m_vertices[i]);
-      }
+        let vertexCount = shape.m_count;
+        b2Assert(vertexCount <= b2_maxPolygonVertices);
+        let vertices = new Array(b2_maxPolygonVertices);
+
+        for (let i = 0; i < vertexCount; ++i) {
+          vertices[i] = b2Mul(xf, shape.m_vertices[i]);
+        }
 
         g_debugDraw.DrawSolidPolygon(vertices, vertexCount, color);
-    }
+      }
       break;
 
     default:
@@ -86,98 +90,81 @@ function DrawShape(fixture, xf, color, g_debugDraw) {
   }
 }
 
-
 world.DrawDebugData = function () {
   if (!this._debugDraw) {
     return;
   }
   let flags = this._debugDraw.GetFlags();
 
-  if (flags & Box2D.b2Draw.e_shapeBit) {
-    for (let b = this.GetBodyList(); b; b = b.GetNext()) {
+  if (flags & b2Draw.e_shapeBit) {
+    for (let b = this.GetBodyList(); typeof b === 'object'; b = b.GetNext()) {
       let xf = b.GetTransform();
-      for (let f = b.GetFixtureList(); f; f = f.GetNext()) {
-        if (b.IsActive() == false)
-        {
-          DrawShape(f, xf, b2Color(0.5, 0.5, 0.3), this._debugDraw);
-        }
-        else if (b.GetType() == Box2D.b2_staticBody)
-        {
+      for (let f = b.GetFixtureList(); typeof f === 'object'; f = f.GetNext()) {
+        if (b.IsActive() == false) {
+          DrawShape(f, xf, new b2Color(0.5, 0.5, 0.3), this._debugDraw);
+        } else if (b.GetType() == b2_staticBody) {
           DrawShape(f, xf, new b2Color(0.5, 0.9, 0.5), this._debugDraw);
-        }
-        else if (b.GetType() == Box2D.b2_kinematicBody)
-        {
+        } else if (b.GetType() == b2_kinematicBody) {
           DrawShape(f, xf, new b2Color(0.5, 0.5, 0.9), this._debugDraw);
-        }
-        else if (b.IsAwake() == false)
-        {
+        } else if (b.IsAwake() == false) {
           DrawShape(f, xf, new b2Color(0.6, 0.6, 0.6), this._debugDraw);
-        }
-        else
-        {
+        } else {
           DrawShape(f, xf, new b2Color(0.9, 0.7, 0.7), this._debugDraw);
         }
       }
     }
   }
 
-  if (flags & b2Draw.e_jointBit)
-  {
-    for (let j = m_jointList; j; j = j.GetNext())
-    {
+  if (flags & b2Draw.e_jointBit) {
+    for (let j = m_jointList; j; j = j.GetNext()) {
       DrawJoint(j);
     }
   }
 
-  if (flags & b2Draw.e_aabbBit)
-  {
-    let color = new Box2D.b2Color(0.9, 0.3, 0.9);
+  if (flags & b2Draw.e_aabbBit) {
+    let color = new b2Color(0.9, 0.3, 0.9);
     let bp = m_contactManager.m_broadPhase;
 
-    for (let b = this.m_bodyList; b; b = b.GetNext())
-    {
-      if (b.IsActive() == false)
-      {
+    for (let b = this.m_bodyList; b; b = b.GetNext()) {
+      if (b.IsActive() == false) {
         continue;
       }
 
-      for (let f = b.GetFixtureList(); f; f = f.GetNext())
-      {
-        for (let i = 0; i < f.m_proxyCount; ++i)
-        {
+      for (let f = b.GetFixtureList(); f; f = f.GetNext()) {
+        for (let i = 0; i < f.m_proxyCount; ++i) {
           let proxy = f.m_proxies + i;
           let aabb = bp.GetFatAABB(proxy.proxyId);
-          let vs = [new Vec2(), new Vec2(), new Vec2(), new Vec2()];
+          let vs = [new b2Vec2(), new b2Vec2(), new b2Vec2(), new b2Vec2()];
           vs[0].Set(aabb.lowerBound.x, aabb.lowerBound.y);
           vs[1].Set(aabb.upperBound.x, aabb.lowerBound.y);
           vs[2].Set(aabb.upperBound.x, aabb.upperBound.y);
           vs[3].Set(aabb.lowerBound.x, aabb.upperBound.y);
 
-            this._debugDraw.DrawPolygon(vs, 4, color);
+          this._debugDraw.DrawPolygon(vs, 4, color);
         }
       }
     }
   }
 
-  if (flags & Box2D.b2Draw.e_centerOfMassBit)
-  {
-    for (let b = this.m_bodyList; b; b = b.GetNext())
-    {
+  if (flags & b2Draw.e_centerOfMassBit) {
+    for (let b = this.m_bodyList; b; b = b.GetNext()) {
       let xf = b.GetTransform();
       xf.p = b.GetWorldCenter();
-        this._debugDraw.DrawTransform(xf);
+      this._debugDraw.DrawTransform(xf);
     }
   }
 };
+
 let lastTimestamp;
 exports.step = function () {
   let now = Date.now();
-  let stepRate = (now - lastTimestamp) / 1000;
+  let stepRate = (now - lastTimestamp) / 1000.0;
   lastTimestamp = now;
   world.Step(stepRate, 10, 10);
   world.DrawDebugData();
 };
 
 exports.init = function (debugDraw) {
+  CreateTestObjects();
   world._debugDraw = debugDraw;
 };

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,9 +8,9 @@
 <script>
     (function () {
         'use strict';
-        let demo = require('remote').require('./demo');
+        let demo = require('./demo');
 
-        let drawScale = 2, alpha = 1, fillAlpha = 1, xformScale = 1, drawFlags = 0;
+        let drawScale = 2, alpha = 1, fillAlpha = 1, xformScale = 1, drawFlags = 1;
         let width = 640;
         let height = 480;
         let canvas = document.createElement('canvas');
@@ -24,7 +24,6 @@
         function _color(color, alpha) {
             return 'rgba(' + ((color & 0xFF0000) >> 16) + ',' + ((color & 0xFF00) >> 8) + ',' + (color & 0xFF) + ',' + alpha + ')';
         }
-
 
         function DrawCircle (center, radius, color, solid, axis) {
             if (!radius) return;
@@ -111,13 +110,15 @@
                 ctx.stroke();
             }
         };
-        let lastTimestamp = 0;
+
         demo.init(debugDraw);
+
+        let lastTimestamp = 0;
         (function loop() {
             let fps = 60;
             let now = Date.now();
             let diff = now - lastTimestamp;
-            if (diff > (1000.0/fps)) {
+            if (diff > (1000.0 / fps)) {
                 ctx.clearRect(0, 0, 854, 400);
                 lastTimestamp = now;
                 demo.step();

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,21 +1,57 @@
-'use strict';
-let app = require('app');
-let BrowserWindow = require('browser-window');
-let ipc = require('ipc');
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
 
-require('crash-reporter').start();
+const path = require('path')
+const url = require('url')
 
-let mainWindow = null;
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
 
-app.on('window-all-closed', () => process.platform != 'darwin' && app.quit());
+function createWindow() {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({ width: 800, height: 600 })
 
-app.on('ready', () => {
-  mainWindow = new BrowserWindow({width: 800, height: 600});
-  mainWindow.loadUrl(`file://${__dirname}/index.html`);
-  //mainWindow.openDevTools();
-  mainWindow.on('closed', function() {
-    mainWindow = null;
-  });
-});
+  // and load the index.html of the app.
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
 
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
 
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,7 +2,7 @@
   "name": "box2d-native-demo",
   "main": "index.js",
   "engines": {
-    "node": "^6.10.3"
+    "node": "^6.11.2"
   },
   "dependencies": {
     "box2d-native": "file:..",

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,13 +2,13 @@
   "name": "box2d-native-demo",
   "main": "index.js",
   "engines": {
-    "node": "4.2.1"
+    "node": "^6.10.3"
   },
   "dependencies": {
     "box2d-native": "file:..",
-    "electron-prebuilt": "^0.34.2"
+    "electron-prebuilt": "1.2.7"
   },
   "scripts": {
-    "start": "node node_modules/.bin/electron ."
+    "start": "electron ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "box2d-native",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "Box2D as native addon",
   "repository": {
     "type": "git",
@@ -8,14 +8,14 @@
   },
   "main": "Box2D.js",
   "engines": {
-    "node": ">=4.2.1"
+    "node": "^6.10.3"
   },
   "config": {
     "box2d_url": "https://codeload.github.com/erincatto/Box2D/tar.gz/v2.3.1",
-    "swig_url": "http://prdownloads.sourceforge.net/swig/swig-3.0.7.tar.gz",
+    "swig_url": "http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz",
     "box2d_arch_name": "Box2D-2.3.1.tar.gz",
-    "swig_arch_name": "swig-3.0.7.tar.gz",
-    "swig_dir": "swig-3.0.7",
+    "swig_arch_name": "swig-3.0.12.tar.gz",
+    "swig_dir": "swig-3.0.12",
     "box2d_dir": "Box2D-2.3.1/Box2D",
     "box2d_cmake_lists_path": "Box2D-2.3.1/Box2D/Box2D/CMakeLists.txt"
   },
@@ -35,8 +35,8 @@
     "clean:swig": "rm -rf $npm_package_config_swig_dir && rm -rf $npm_package_config_swig_arch_name",
     "clean": "npm run clean:Box2D && npm run clean:swig && rm -rf Box2D_wrap.cxx",
     "preinstall": "npm run clean && npm run get && npm run untar && npm run patch && npm run make && npm run wrap",
-    "install": "node-gyp configure && node-gyp build",
-    "prepublish": "node node_modules/.bin/babel Box2D.es6 --out-file Box2D.js --source-maps --whitelist strict,es6.modules,es6.parameters,es6.spread,es6.destructuring",
+    "install": "node-gyp --target=v6.10.0 configure && node-gyp --target=v6.10.0 build",
+    "prepublish": "node node_modules/.bin/babel Box2D.es6 --out-file Box2D.js --presets es2015 --source-maps --whitelist strict,es6.modules,es6.parameters,es6.spread,es6.destructuring",
     "postinstall": "npm run clean",
     "test": "node node_modules/.bin/mocha -r tests/bootstrap.js tests/**/*.spec.js"
   },
@@ -45,12 +45,14 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "babel": "^5.8.29",
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "bindings": "^1.2.1",
-    "lodash": "^3.10.1"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "mocha": "^2.3.3",
-    "should": "^7.1.1"
+    "babel-register": "^6.24.1",
+    "mocha": "^3.4.1",
+    "should": "^11.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "Box2D.js",
   "engines": {
-    "node": "^6.10.3"
+    "node": "^6.11.2"
   },
   "config": {
     "box2d_url": "https://codeload.github.com/erincatto/Box2D/tar.gz/v2.3.1",
@@ -35,7 +35,7 @@
     "clean:swig": "rm -rf $npm_package_config_swig_dir && rm -rf $npm_package_config_swig_arch_name",
     "clean": "npm run clean:Box2D && npm run clean:swig && rm -rf Box2D_wrap.cxx",
     "preinstall": "npm run clean && npm run get && npm run untar && npm run patch && npm run make && npm run wrap",
-    "install": "node-gyp --target=v6.10.0 configure && node-gyp --target=v6.10.0 build",
+    "install": "node-gyp --target=v6.11.0 configure && node-gyp --target=v6.11.0 build",
     "prepublish": "node node_modules/.bin/babel Box2D.es6 --out-file Box2D.js --presets es2015 --source-maps --whitelist strict,es6.modules,es6.parameters,es6.spread,es6.destructuring",
     "postinstall": "npm run clean",
     "test": "node node_modules/.bin/mocha -r tests/bootstrap.js tests/**/*.spec.js"

--- a/tests/Box2D.i.spec.js
+++ b/tests/Box2D.i.spec.js
@@ -1,24 +1,38 @@
 'use strict';
-import 'should';
-import {Vec2, World, BodyDef, EdgeShape, CircleShape, _dynamicBody} from '../';
+import assert from 'assert';
+import should from 'should';
+import { Vec2, World, BodyDef, EdgeShape, CircleShape, _dynamicBody } from '../';
+
+// Need to override should.deepEqual here because the default should.deepEqual actually just uses assert.equal
+// instead of asset.deepEqual which causes these tests to fail because of slightly different prototypes
+should.Assertion.add('deepEqual', function (obj2) {
+  this.params = {
+    operator: 'expected ' + this.obj + ' to deepEqual ' + obj2,
+    expected: obj2,
+    showDiff: true
+  };
+  assert.deepEqual(this.obj, obj2, 'expected ' + this.obj + ' ' + JSON.stringify(this.obj) + ' to deepEqual ' + obj2 + ' ' + JSON.stringify(obj2));
+}, false);
 
 let world = new World(new Vec2(0, 0));
 
-describe('Box2D.i', () => {
-  describe('%typemap(out) b2Shape*', () => [CircleShape, EdgeShape].forEach((Shape) => describe(`for ${Shape.name}`, () => {
-    let shape = new Shape();
+describe('Box2D.i', function () {
+  var shapes = [CircleShape, EdgeShape];
+  shapes.forEach(function (Shape) {
+    describe(`for ${Shape.name}`, function () {
+      let shape = new Shape();
 
-    it(`should return ${Shape.name}`, () => world
-      .CreateBody(
-        Object.assign(
-          new BodyDef(),
-          {
-            position: new Vec2(0, 0),
-            type: _dynamicBody
-          }
-        )
-      )
-      .CreateFixture(shape, 0)
-      .GetShape().should.be.eql(shape));
-  })));
+      let bodyDef = new BodyDef();
+      bodyDef.position = new Vec2(0, 0);
+      bodyDef.type = _dynamicBody;
+
+      let body = world.CreateBody(bodyDef);
+
+      let fixture = body.CreateFixture(shape, 0);
+
+      it(`should return ${Shape.name}`, function () {
+        fixture.GetShape().should.deepEqual(shape);
+      });
+    });
+  });
 });

--- a/tests/World.spec.js
+++ b/tests/World.spec.js
@@ -1,21 +1,18 @@
 'use strict';
 import 'should';
-import {World, Vec2, BodyDef, Body} from '../';
+import { World, Vec2, BodyDef, Body } from '../';
 
 describe('World', () => {
   let gravity = new Vec2(0, 0);
-  it('should be created without an error', () => new World(gravity));
+  it('should be created without an error', function () { new World(gravity).should.be.ok; });
 
-  describe('methods', () => {
-    let world;
-    beforeEach(() => world = new World(gravity));
+  let world;
+  beforeEach(function () { world = new World(gravity) });
 
-    describe('#Step()', () => {
-      it('should step without an error', () => world.Step(0, 0, 0));
-    });
-    describe('#CreateBody()', () => {
-      it('should create body without an error', () => world.CreateBody(new BodyDef()).should.be.ok);
-    });
+  describe('#Step()', function () {
+    it('should step without an error', function () { world.Step(0, 0, 0); });
   });
-
+  describe('#CreateBody()', function () {
+    it('should create body without an error', function () { world.CreateBody(new BodyDef()).should.be.ok; });
+  });
 });

--- a/tests/bootstrap.js
+++ b/tests/bootstrap.js
@@ -1,10 +1,4 @@
 'use strict';
-require('babel/register')({
-  whitelist: [
-    'es6.modules',
-    'strict',
-    'es6.parameters',
-    'es6.spread',
-    'es6.destructuring'
-  ]
+require('babel-register')({
+  presets: [ 'es2015' ]
 });


### PR DESCRIPTION
This PR updates Node to v6.11.2. It also updates all dependencies to the latest versions that are possible while maintaining support for Node v6.11.2.

I tried updating to Node v7.10.0 but it appears that SWIG doesn't yet support it as I got a bunch of compile errors so decided that v6.11.2 was a good compromise.